### PR TITLE
Add Vagrant box for local testing of Ansible playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ ansible/roles/haxorof.docker_ce
 ansible/roles/andrewrothstein.bash
 ansible/roles/andrewrothstein.docker-compose
 ansible/roles/andrewrothstein.git
+
+.vagrant/
+ubuntu-bionic-18.04-cloudimg-console.log
+vagrant_variables.yml

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -60,6 +60,15 @@ Vagrant.configure("2") do |config|
       "empty" => [settings['hostname']]
     }
     ansible.raw_arguments = ["--verbose", "--diff"]
+    # ansible.raw_arguments = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
+    #
+    # # CLI command.
+    # ANSIBLE_ARGS='--extra-vars "some_var=value"' vagrant up
+    #
+    # This allows the playbook to work either way (with or without any
+    # ANSIBLE_ARGS).
+    #
+    # https://gist.github.com/phantomwhale/9657134#gistcomment-2130145
   end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "ubuntu/bionic64"
+  config.vm.box = "ubuntu/focal64"
   config.vm.define settings['hostname']
   config.vm.hostname = settings['hostname']
   # thin provisioning, won't take 50G upfront

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,52 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby tabstop=8 expandtab shiftwidth=2 softtabstop=2 :
+
+require 'yaml'
+config_file=File.expand_path(File.join(File.dirname(__FILE__), 'vagrant_variables.yml'))
+settings=YAML.load_file(config_file)
+
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  config.vagrant.plugins = ["vagrant-disksize", "vagrant-vbguest"]
+
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/bionic64"
+  config.vm.define settings['hostname']
+  config.vm.hostname = settings['hostname']
+  # thin provisioning, won't take 50G upfront
+  config.disksize.size = settings.fetch('disksize', '50GB')
+
+  # bug https://github.com/hashicorp/vagrant/issues/3341 still happening as of
+  # 2019-10-31 with VirtualBox 6.0.12
+  config.vbguest.auto_update = false
+
+  # bridge networking to get real DNS name on local network
+  if settings.has_key?('hostip')
+    if settings.has_key?('network_bridge')
+      config.vm.network "public_network", ip: settings['hostip'], bridge: settings['network_bridge']
+    else
+      config.vm.network "public_network", ip: settings['hostip']
+    end
+  else
+    if settings.has_key?('network_bridge')
+      config.vm.network "public_network", bridge: settings['network_bridge']
+    else
+      config.vm.network "public_network"
+    end
+  end
+
+  config.vm.provider "virtualbox" do |v|
+      v.memory = settings.fetch('memory', 4096)
+      v.cpus = settings.fetch('cpus', 2)
+  end
+
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,4 +49,17 @@ Vagrant.configure("2") do |config|
       v.cpus = settings.fetch('cpus', 2)
   end
 
+  #
+  # Run Ansible from the Vagrant Host
+  #
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "ansible/site.yml"
+    ansible.config_file = "ansible/ansible.cfg"
+    ansible.limit = "empty"
+    ansible.groups = {
+      "empty" => [settings['hostname']]
+    }
+    ansible.raw_arguments = ["--verbose", "--diff"]
+  end
+
 end

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,7 @@
+[defaults]
+# https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-stdout-callback
+# Make stdout more readable with line breaks.
+ANSIBLE_STDOUT_CALLBACK=debug
+
+# https://docs.ansible.com/ansible/latest/reference_appendices/config.html#max-file-size-for-diff
+ANSIBLE_MAX_DIFF_SIZE=1044480

--- a/ansible/sample-inventory
+++ b/ansible/sample-inventory
@@ -1,3 +1,6 @@
 [gitlab]
 production-gitlab.fqdn.hostname gitlab_ce_version=master  gitlab_ce_root_pass=prod-rootpass gitlab_ce_smtp=mail.example.com
 staging-gitlab.fqdn.hostname    gitlab_ce_version=develop gitlab_ce_root_pass=stag-rootpass gitlab_ce_smtp=mail.example.com
+
+[empty]
+some-empty-docker-host

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -4,3 +4,9 @@
     - { role: andrewrothstein.docker-compose, tags: ["docker-compose"] }
     - { role: andrewrothstein.git, tags: ["git"] }
     - { role: gitlab-ce, tags: ["gitlab-ce"] }
+
+- hosts: empty
+  roles:
+    - { role: haxorof.docker_ce, tags: ["docker"] }
+    - { role: andrewrothstein.docker-compose, tags: ["docker-compose"] }
+    - { role: andrewrothstein.git, tags: ["git"] }

--- a/vagrant_variables.yml.example
+++ b/vagrant_variables.yml.example
@@ -1,0 +1,19 @@
+---
+hostname: myhostname
+
+# Set network bridge, else you'll simply be prompted on vagrant up.
+# network_bridge: enp0s25
+
+# Set hostip if you want to force an IP, useful to keep the same IP after each
+# VM destroy and recreate.
+# hostip: 1.2.3.4
+
+# Force a default gateway if networking issue (ex: VM in a different DMZ VLan).
+# default_gateway: 1.2.3.4
+
+
+# VM Settings
+#
+# memory: 4096
+# cpus: 2
+# disksize: '50GB'


### PR DESCRIPTION
Currently the Vagrant box is hardcoded to provision ansible host name "empty" only.

This hardcode should be configurable later.